### PR TITLE
feature: minute aggregation for gateway stats

### DIFF
--- a/chirpstack/src/uplink/stats.rs
+++ b/chirpstack/src/uplink/stats.rs
@@ -153,10 +153,15 @@ impl Stats {
             m.metrics.insert(format!("rx_dr_{}", k), *v as f64);
         }
 
+        let mut aggregations = metrics::Aggregation::default_aggregations();
+        if !aggregations.contains(&metrics::Aggregation::MINUTE) {
+            aggregations.push(metrics::Aggregation::MINUTE);
+        }
+
         metrics::save(
             &format!("gw:{}", self.gateway.as_ref().unwrap().gateway_id),
             &m,
-            &metrics::Aggregation::default_aggregations(),
+            &aggregations,
         )
         .await
         .context("Save gateway stats")?;


### PR DESCRIPTION
This change adds minute level aggregation to gateway metrics, since by default all metrics other than the gateway duty-cycle metrics only get saved with aggregation levels: **hour, day, month** but not with aggregation level: **minute**.

The reason we need to add minute level aggregation to the gateway metrics is enable us to know the latest downlink message the gateway received on a minute-wise resolution.