### PR TITLE
add mqtt enabled regions

### DIFF
--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -55,7 +55,7 @@
   # Network identifier (NetID, 3 bytes) encoded as HEX (e.g. 010203).
   net_id = "000000"
 
-  # Enabled regions.
+  # Enabled regions for band plan configuration.
   #
   # Multiple regions can be enabled simultaneously. Each region must match
   # the 'name' parameter of the region configuration in '[[regions]]'.
@@ -77,6 +77,27 @@
     "us915_1",
   ]
 
+  # Enabled regions for MQTT gateway bridge.
+  #
+  # Multiple regions can be enabled simultaneously. Each region must match
+  # the 'name' parameter of the region configuration in '[[regions]]'.
+  mqtt_enabled_regions = [
+    "as923",
+    "as923_2",
+    "as923_3",
+    "as923_4",
+    "au915_0",
+    "cn470_10",
+    "cn779",
+    "eu433",
+    "eu868",
+    "in865",
+    "ism2400",
+    "kr920",
+    "ru864",
+    "us915_0",
+    "us915_1",
+  ]
 
 # API interface configuration.
 [api]

--- a/chirpstack/src/cmd/configfile.rs
+++ b/chirpstack/src/cmd/configfile.rs
@@ -208,12 +208,22 @@ r#"
     {{/each}}
   ]
 
-  # Enabled regions.
+  # Enabled regions for band plan configuration.
   #
   # Multiple regions can be enabled simultaneously. Each region must match
   # the 'name' parameter of the region configuration in '[[regions]]'.
   enabled_regions=[
     {{#each network.enabled_regions}}
+    "{{this}}",
+    {{/each}}
+  ]
+
+  # Enabled regions for MQTT gateway bridge.
+  #
+  # Multiple regions can be enabled simultaneously. Each region must match
+  # the 'name' parameter of the region configuration in '[[regions]]'.
+  mqtt_enabled_regions=[
+    {{#each network.mqtt_enabled_regions}}
     "{{this}}",
     {{/each}}
   ]

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -158,6 +158,7 @@ pub struct Network {
     pub secondary_net_ids: Vec<NetID>,
     pub dev_addr_prefixes: Vec<DevAddrPrefix>,
     pub enabled_regions: Vec<String>,
+    pub mqtt_enabled_regions: Vec<String>,
     #[serde(with = "humantime_serde")]
     pub device_session_ttl: Duration,
     #[serde(with = "humantime_serde")]
@@ -176,6 +177,7 @@ impl Default for Network {
             secondary_net_ids: vec![],
             dev_addr_prefixes: vec![],
             enabled_regions: vec![],
+            mqtt_enabled_regions: vec![],
             device_session_ttl: Duration::from_secs(60 * 60 * 24 * 31),
             deduplication_delay: Duration::from_millis(200),
             get_downlink_data_delay: Duration::from_millis(100),

--- a/chirpstack/src/gateway/backend/mod.rs
+++ b/chirpstack/src/gateway/backend/mod.rs
@@ -30,7 +30,7 @@ pub async fn setup() -> Result<()> {
 
     info!("Setting up gateway backends for the different regions");
     for region in &conf.regions {
-        if !conf.network.enabled_regions.contains(&region.id) {
+        if !conf.network.mqtt_enabled_regions.contains(&region.id) {
             continue;
         }
 

--- a/chirpstack/src/test/mod.rs
+++ b/chirpstack/src/test/mod.rs
@@ -41,6 +41,7 @@ pub async fn prepare<'a>() -> std::sync::MutexGuard<'a, ()> {
     conf.redis.servers = vec![env::var("TEST_REDIS_URL").unwrap()];
     conf.sqlite.path = ":memory:".to_string();
     conf.network.enabled_regions = vec!["eu868".to_string()];
+    conf.network.mqtt_enabled_regions = vec!["eu868".to_string()];
     conf.regions = vec![config::Region {
         id: "eu868".to_string(),
         description: "EU868".to_string(),


### PR DESCRIPTION
We want to handle mqtt gateway bridge regions different from band plan config regions.
So adding a new attribute to decouple mqtt from the plan region.
Actually values will be something like

enabled_regions = [
    "AU_915_928_FSB_1",
    "AU_915_928_FSB_2",
    "AU_915_928_FSB_3",
    "AU_915_928_FSB_1_AND_FSB_2",
    "AU_915_928_FSB_1_AND_FSB_3",
    "AU_915_928_FSB_2_AND_FSB_3",
    "AU_915_928_FSB_1_AND_FSB_2_AND_FSB_3",
]

mqtt_enabled_regions = [
    "AU_915_928_FSB_1_AND_FSB_2_AND_FSB_3",
]