### PR TITLE
Try not to attempt to dequeue pending messages that are already locked.

### DIFF
--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -675,6 +675,7 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                 order by
                                     qi.created_at
                                 limit $1
+                                for update skip locked
                             )
                         returning *
                     "#


### PR DESCRIPTION
We've observed a few deadlocks, example from the error log:

```
2025-03-27 04:13:16 UTC:10.5.2.165(37608):chirpstack@chirpstack:[9998]:DETAIL: Process 9998 waits for ExclusiveLock on tuple (639,5) of relation 20814 of database 20531; blocked by process 10068.
Process 10068 waits for ShareLock on transaction 1604224145; blocked by process 9989.
Process 9989 waits for ShareLock on transaction 1604223654; blocked by process 9998.

Process 9998:
update
multicast_group_queue_item
set
scheduler_run_after = $3
where
id in (
select
qi.id
from
multicast_group_queue_item qi
inner join gateway g
on g.gateway_id = qi.gateway_id
where
qi.scheduler_run_after <= $2
-- check that the gateway is online, except when the item already has expired
and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
order by
qi.created_at
limit $1
)
returning *

Process 10068:
update
multicast_group_queue_item
set
scheduler_run_after = $3
where
id in (
select
qi.id
from
multicast_group_queue_item qi
inner join gateway g
on g.gateway_id = qi.gateway_id
where
qi.scheduler_run_after <= $2
-- check that the gateway is online, except when the item already has expired
and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
order by
qi.created_at
limit $1
)
returning *

Process 9989:
update
multicast_group_queue_item
set
scheduler_run_after = $3
where
id in (
select
qi.id
from
multicast_group_queue_item qi
inner join gateway g
on g.gateway_id = qi.gateway_id
where
qi.scheduler_run_after <= $2
-- check that the gateway is online, except when the item already has expired
and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
order by
qi.created_at
limit $1
)
returning *

2025-03-27 04:13:16 UTC:10.5.2.165(37608):chirpstack@chirpstack:[9998]:HINT: See server log for query details.
2025-03-27 04:13:16 UTC:10.5.2.165(37608):chirpstack@chirpstack:[9998]:STATEMENT:
update
multicast_group_queue_item
set
scheduler_run_after = $3
where
id in (
select
qi.id
from
multicast_group_queue_item qi
inner join gateway g
on g.gateway_id = qi.gateway_id
where
qi.scheduler_run_after <= $2
-- check that the gateway is online, except when the item already has expired
and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
order by
qi.created_at
limit $1
)
returning *
```

I still don't understand how exactly we achieve a _deadlock_ though. I would lock _contention_ i.e. things getting slow due to waiting for locks. I don't see how the loop gets closed to cause a _dead_lock.