### PR TITLE
Try to mitigate multicast deadlocks.

### DIFF
--- a/api/grpc-web/package.json
+++ b/api/grpc-web/package.json
@@ -12,5 +12,6 @@
     "@types/google-protobuf": "^3.15.12",
     "google-protobuf": "^3.21.2",
     "grpc-web": "^1.5.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/chirpstack/Makefile
+++ b/chirpstack/Makefile
@@ -8,6 +8,9 @@ else
 	VARIANT_FLAGS ?= --variant="$(DATABASE)"
 endif
 
+debug-check:
+	cargo check --no-default-features --features="$(DATABASE)"
+
 debug-amd64:
 	cross build --target x86_64-unknown-linux-musl --no-default-features --features="$(DATABASE)"
 

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -1226,19 +1226,6 @@ pub mod test {
             // We expect zero items, as the gateway is not online.
             let out = get_schedulable_queue_items(100).await.unwrap();
             assert_eq!(0, out.len());
-
-            // Set the expires_at of the queue item to now.
-            diesel::update(
-                multicast_group_queue_item::dsl::multicast_group_queue_item.find(&qi.id),
-            )
-            .set(multicast_group_queue_item::expires_at.eq(Some(Utc::now())))
-            .execute(&mut get_async_db_conn().await.unwrap())
-            .await
-            .unwrap();
-
-            // We expect one item, as it has expired.
-            let out = get_schedulable_queue_items(100).await.unwrap();
-            assert_eq!(1, out.len());
         }
     }
 }

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -670,8 +670,10 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                     on g.gateway_id = qi.gateway_id
                                 where
                                     qi.scheduler_run_after <= $2
-                                    -- check that the gateway is online, except when the item already has expired
-                                    and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
+                                    -- check that the gateway is online
+                                    and (
+                                        $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
+                                    )
                                 order by
                                     qi.created_at
                                 limit $1

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -675,7 +675,7 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                         $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
                                     )
                                     -- ignore expired messages
-                                    and not (qi.expires_at < $2)
+                                    and not (qi.expires_at is not null and qi.expires_at < $2)
                                 order by
                                     qi.created_at
                                 limit $1

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -679,6 +679,7 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                 order by
                                     qi.created_at
                                 limit $1
+                                for update skip locked
                             )
                         returning *
                     "#

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -674,6 +674,8 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                     and (
                                         $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
                                     )
+                                    -- ignore expired messages
+                                    and not (qi.expires_at < $2)
                                 order by
                                     qi.created_at
                                 limit $1


### PR DESCRIPTION
A few things we believe to be going on:

1) Expired messages are deleted one by one in [`Multicast::validate_expiration()`](https://github.com/halter/chirpstack/blob/07364fb05d06f95317f3efde0b1d263d61343ad4/chirpstack/src/downlink/multicast.rs#L113) which is quite inefficient. This seems to contribute to CPU load on the chirpstack tasks leading to chirpstack falling behind -> more expired messages to handle -> more locks on the table -> eventually two schedulers manage to deadlock each other.
    - So we will instead ignore expired messages completely in the main scheduler loop.
    - Instead, we will (later) implement an out-of-band cleanup like the following:

```sql
DELETE FROM multicast_group_queue_item
WHERE id IN (
  SELECT id FROM multicast_group_queue_item
  WHERE expiry_at < now()
  FOR UPDATE SKIP LOCKED
)
```

2) Concurrent scheduler loops can step on each other's toes and cause deadlocks. The table is simply a task queue, so if a row is locked we can safely assume some other thread has picked up the task and we don't need to worry about it. So we add `FOR UPDATE SKIP LOCKED`.
    - Refer https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE